### PR TITLE
Improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,69 @@ data_store.hdu_table
 > [!WARNING]  
 > Due to some change in gammapy 1.3, it's strongly suggested to use only use models that have been created with the same version of gammapy used
 
+## Logging setup
+
+The module uses `logging` to output various information to the user. Standard `logging` functionalities are supported.
+
+In addition, some helper functions are implemented and BAccMod uses a logging level **MOREINFO** with value 15 between the `logging` INFO and DEBUG levels.
+
+Logging functions can be used as follow :
+
+```python
+from baccmod.logging import MOREINFO, set_log_level
+
+set_log_level(level= MOREINFO, # Supports both int and string representation, e.g.
+                               # 15, MOREINFO and 'MOREINFO' would be equivalent
+              module= 'baccmod' # default 'baccmod', 'baccmod.' is automatically 
+                                # added if missing so users can provide a 
+                                # submodule directly
+              )
+
+# Example usage : 
+set_log_level(logging.INFO)
+set_log_level('WARNING')
+set_log_level(20, 'grid3d_acceptance_map_creator')
+# equivalent to
+set_log_level(level=logging.INFO,
+              module='baccmod.grid3d_acceptance_map_creator')
+
+```
+
+The `set_log_level` function has some simple usages show below but takes a number of optionnal parameters for more advance configuration. Its signature is :
+```python
+setup_logging_output(output_file=None, use_terminal=True,
+                     handlers=None, module='baccmod',
+                     fmode='w', term_level=logging.NOTSET,
+                     log_format='%(levelname)s:%(name)s: %(message)s')
+```
+
+Some usages :
+
+```python
+from baccmod.logging import set_log_level, setup_logging_output
+
+# Setup the output of logging to the provided file. Keep output in terminal.
+setup_logging_output(output_file='/path/to/log_file.log') 
+
+# Setup the output of logging to the provided file. No output in terminal.
+setup_logging_output(output_file='/path/to/log_file.log', use_terminal=False)
+
+# Setup a file output with a global log level of INFO,
+# but only output WARNING and above levels to the terminal
+set_log_level('INFO')
+setup_logging_output(output_file='/path/to/log_file.log',
+                     use_terminal=True,
+                     term_level='WARNING')
+```
+`module` can be used to define the logging for a submodule only.
+
+`fmode` defines the writing strategy for the log file (default overwrites).
+
+`log_format` can be used to change the format of the messages.
+
+`handlers` (advanced users) allow to directly provide a list of Handlers instead of the one created by the `output_file` and `use_terminal` options.
+
+
 
 ## Telescope position
 

--- a/baccmod/__init__.py
+++ b/baccmod/__init__.py
@@ -10,6 +10,3 @@ from .base_acceptance_map_creator import BaseAcceptanceMapCreator
 from .grid3d_acceptance_map_creator import Grid3DAcceptanceMapCreator
 from .radial_acceptance_map_creator import RadialAcceptanceMapCreator
 from .bkg_collection import BackgroundCollectionZenith
-
-import logging
-logging.basicConfig()

--- a/baccmod/logging.py
+++ b/baccmod/logging.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------
+# Filename: logging.py
+# Purpose: Setup logging and related functions.
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+# ---------------------------------------------------------------------
+import logging
+import sys
+
+# Define custom logging levels
+MOREINFO=15
+logging.addLevelName(MOREINFO, "MOREINFO")
+
+def set_log_level(level, module='baccmod'):
+    if not 'baccmod' in module:
+        module = 'baccmod.' + module
+    logging.getLogger(module).setLevel(level)
+
+def setup_logging_output(output_file=None, use_terminal=True,
+                         handlers=None, module='baccmod',
+                         fmode='w', term_level=logging.NOTSET,
+                         log_format='%(levelname)s:%(name)s: %(message)s'):
+    """
+    Setup output streams to file. Also allows for more complex logging options,
+    including directly providing handlers or a new message format.
+
+    Parameters
+    ----------
+    output_file: str
+        Path of the output file.
+    use_terminal: bool
+        Whether to use a terminal handler or not.
+    handlers: list
+        If provided, ignore other parameters and use the provided handlers.
+    fmode: str
+        Mode used to open the output file. Default overwrites existing file.
+    term_level: int or str
+        Logging level for the terminal output. Useful to have different logging
+        level in the output file and terminal.
+    module: str
+        (Sub)module whose logger we configure. Cn only be a submodule of BAccMod.
+    log_format: str
+        Logging format.
+
+    """
+    if not 'baccmod' in module:
+        module = 'baccmod.' + module
+    logger = logging.getLogger(module)
+    formatter = logging.Formatter(log_format)
+    if handlers is not None:
+        for h in handlers:
+            h.setFormatter(formatter)
+    else:
+        handlers=[]
+        if output_file is not None:
+            h = logging.FileHandler(output_file, mode=fmode)
+            h.setFormatter(formatter)
+            handlers.append(h)
+        if use_terminal:
+            h = logging.StreamHandler(sys.stderr)
+            h.setFormatter(formatter)
+            h.setLevel(term_level)
+            handlers.append(h)
+    logger.handlers = handlers


### PR DESCRIPTION
This PR removes the call to basicConfig (bad practice) in the init file.
It also creates a new module implementing baccmod methods to setup logging level and output in a user-friendlier approach compared to using logging directly, and a new logging level.

In particular, it allows to add an output files with the logging output. Also it is possible to suppress the terminal output, or to use a different logging level in terminal compared to the one used in the file (defined globally).
Other options include providing log message handlers (for advance logging users), to change the writing mode of the log file, and to change the logging message format.