### PR TITLE
Improve logging,  mostly for the fit method in grid3d

### DIFF
--- a/baccmod/base_acceptance_map_creator.py
+++ b/baccmod/base_acceptance_map_creator.py
@@ -629,9 +629,6 @@ class BaseAcceptanceMapCreator(ABC):
             binned_observations[np.digitize(np.cos(obs.get_pointing_altaz(obs.tmid).zen), cos_zenith_bin) - 1].append(
                 obs)
 
-        # Compute the model for each bin
-        binned_model = [self.create_acceptance_map(binned_obs) for binned_obs in binned_observations]
-
         # Determine the center of the bin (weighted as function of the livetime of each observation)
         bin_center = []
         for i in range(len(binned_observations)):
@@ -659,6 +656,12 @@ class BaseAcceptanceMapCreator(ABC):
                     f"{wobble} observation per bin: {list(np.histogram(cos_zenith_observations, bins=cos_zenith_bin, weights=1 * wobble_observations_bool_arr[i])[0])}")
                 logger.info(
                     f"{wobble} livetime per bin: {list(np.histogram(cos_zenith_observations, bins=cos_zenith_bin, weights=livetime_observations_and_wobble[i])[0].astype(int))}")
+
+        # Compute the model for each bin
+        binned_model = []
+        for i, binned_obs in enumerate(binned_observations):
+            logger.info(f"Creating model for the bin at cos zenith = {np.round(bin_center[i], 2)}°")
+            binned_model.append(self.create_acceptance_map(binned_obs))
 
         # Create the dict for output of the function
         collection_binned_model = BackgroundCollectionZenith()

--- a/baccmod/grid3d_acceptance_map_creator.py
+++ b/baccmod/grid3d_acceptance_map_creator.py
@@ -25,6 +25,7 @@ from regions import SkyRegion
 
 from .base_acceptance_map_creator import BaseAcceptanceMapCreator
 from .modeling import FIT_FUNCTION, log_factorial, log_poisson
+from baccmod.logging import MOREINFO
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +134,8 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
         offset_bins = np.round(np.concatenate((-np.flip(offset_edges), offset_edges[1:]), axis=None), 3)
         self.map_bins = (energy_axis.edges, offset_bins, offset_bins)
 
+        self.sq_rel_residuals = {'mean': [], 'std': []}
+
         # Initiate upper instance
         super().__init__(energy_axis=energy_axis,
                          max_offset=max_offset,
@@ -191,7 +194,7 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
             return -np.sum(
                 log_poisson(count_map, fnc(x, y, *args) * exp_map / exp_map_total, log_factorial_count_map))
 
-        logger.info(f"seeds :\n{seeds}")
+        logger.log(MOREINFO, f"seeds :\n{seeds}")
         m = Minuit(f,
                    name=seeds.keys(),
                    *seeds.values())
@@ -202,14 +205,17 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                 m.limits[key] = bound
         m.errordef = Minuit.LIKELIHOOD
         m.simplex().migrad()
-        if logger.level <= logging.INFO:
+        if not m.valid : logger.warning(f"Fit invalid in energy/Zd bin.")
+        if logger.getEffectiveLevel() <= logging.INFO:
             func = fnc(x, y, **m.values.to_dict()) * exp_map / exp_map_total
             func[exp_map == 0] = 1
             rel_residuals = 100 * (count_map - func) / func
-            logger.info(f"Fit valid : {m.valid}\n"
-                        f"Results ({fnc.__name__}) :\n{m.values.to_dict()}")
-            logger.info("Average relative residuals : %.1f %%," % (np.mean(rel_residuals)) +
+            sq_rel_residuals =  (count_map - func) / np.sqrt(func)
+            logger.log(MOREINFO, f"Results ({fnc.__name__}) :\n{m.values.to_dict()}")
+            logger.debug("Average relative residuals : %.1f %%," % (np.mean(rel_residuals)) +
                         "Std = %.2f %%" % (np.std(rel_residuals)) + "\n")
+            self.sq_rel_residuals['mean'].append(np.mean(sq_rel_residuals))
+            self.sq_rel_residuals['std'].append(np.std(sq_rel_residuals))
 
         return fnc(x, y, **m.values.to_dict())
 
@@ -252,12 +258,17 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
         elif self.method == 'fit':
             logger.info(f"Performing the background fit using {self.fit_fnc}.")
             corrected_counts = np.empty(count_background.shape)
+            self.sq_rel_residuals = {'mean': [], 'std': []}
             for e in range(count_background.shape[0]):
                 logger.info(f"Energy bin : [{self.energy_axis.edges[e]:.2f},{self.energy_axis.edges[e + 1]:.2f}]")
                 corrected_counts[e] = self.fit_background(count_background[e].astype(int),
                                                           exp_map_background_total_downsample.data[e],
                                                           exp_map_background_downsample.data[e],
                                                           )
+
+            logger.info("Average event counts diff/sqrt(fit) for each energies : "
+                        f"{np.round(self.sq_rel_residuals['mean'], 2)}\n" +
+                        f"Std = {np.round(self.sq_rel_residuals['std'], 2)}")
         else:
             raise NotImplementedError(f"Requested method '{self.method}' is not valid.")
         solid_angle = 4. * (np.sin(bin_width_x / 2.) * np.sin(bin_width_y / 2.)) * u.steradian

--- a/baccmod/grid3d_acceptance_map_creator.py
+++ b/baccmod/grid3d_acceptance_map_creator.py
@@ -194,7 +194,7 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
             return -np.sum(
                 log_poisson(count_map, fnc(x, y, *args) * exp_map / exp_map_total, log_factorial_count_map))
 
-        logger.log(MOREINFO, f"seeds :\n{seeds}")
+        logger.debug( f"seeds :\n{seeds}")
         m = Minuit(f,
                    name=seeds.keys(),
                    *seeds.values())


### PR DESCRIPTION
Added log of the cos zenith bin being processed (all cases).

For the fit in the 3D case:
Moved cluter of logs including seeds and fit results for each energy/zenith bins to the new `MOREINFO` level.
`INFO` now only shows the zenith bin being worked with, the energy bin and the mean/std of the `diff/sqrt(fit)` at the end of each zenith bin.
The individual fit validity are not shown in `INFO` anymore. Instead a `WARNING` level log is shown if the fit is not valid only.
The average and std of residuals are now only shown for each fit if the log level is `DEBUG` or lower.

Interest of the new log : mean/std of the `diff/sqrt(fit)`
If the fit is successful,` mean(diff)` should be zero.
If the dispersion of `diff = count - fit` are  purelly statistical, `std(diff/sqrt(fit))` should be 1 assuming a Poisson statistic.