### PR TITLE
Refactor background IRF creation and application to observation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
                                                       offset_axis_acceptance,
                                                       exclude_regions=exclude_regions,
                                                       oversample_map=10)
-acceptance_model = acceptance_model_creator.create_acceptance_map(obs_collection)
+acceptance_model = acceptance_model_creator.create_model(obs_collection)
 
 ```
 

--- a/baccmod/grid3d_acceptance_map_creator.py
+++ b/baccmod/grid3d_acceptance_map_creator.py
@@ -227,7 +227,7 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
 
         return fnc(x, y, **m.values.to_dict())
 
-    def create_acceptance_map(self, observations: Observations) -> Background3D:
+    def create_model(self, observations: Observations) -> Background3D:
         """
         Calculate a 3D grid acceptance map
 

--- a/baccmod/radial_acceptance_map_creator.py
+++ b/baccmod/radial_acceptance_map_creator.py
@@ -124,7 +124,7 @@ class RadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
                          interpolation_cleaning_energy_relative_threshold=interpolation_cleaning_energy_relative_threshold,
                          interpolation_cleaning_spatial_relative_threshold=interpolation_cleaning_spatial_relative_threshold)
 
-    def create_acceptance_map(self, observations: Observations) -> Background2D:
+    def create_model(self, observations: Observations) -> Background2D:
         """
         Calculate a radial acceptance map
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -54,7 +54,7 @@ class TestIntegrationClass:
                                                offset_axis=self.offset_axis,
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155)
-        background_model = bkg_maker.create_acceptance_map(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_model(observations=self.obs_collection_pks_2155)
         assert type(background_model) is Background3D
         reference = Background3D.read('ressource/test_data/reference_model/pks_2155_3D.fits')
         assert np.all(np.isclose(background_model.data, reference.data,
@@ -67,7 +67,7 @@ class TestIntegrationClass:
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155,
                                                method='fit')
-        background_model = bkg_maker.create_acceptance_map(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_model(observations=self.obs_collection_pks_2155)
         assert type(background_model) is Background3D
         reference = Background3D.read('ressource/test_data/reference_model/pks_2155_spatial_fit_bkg.fits')
         for i in range(background_model.data.shape[0]):
@@ -81,7 +81,7 @@ class TestIntegrationClass:
                                                offset_axis=self.offset_axis,
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155)
-        background_model = bkg_maker.create_acceptance_map(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_model(observations=self.obs_collection_pks_2155)
         assert type(background_model) is Background2D
         reference = Background2D.read('ressource/test_data/reference_model/pks_2155_2D.fits')
         assert np.all(np.isclose(background_model.data, reference.data,
@@ -94,7 +94,7 @@ class TestIntegrationClass:
                                                offset_axis=self.offset_axis,
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155)
-        background_model = bkg_maker.create_acceptance_map(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_model(observations=self.obs_collection_pks_2155)
         assert type(background_model) is Background3D
         reference = Background3D.read('ressource/test_data/reference_model/pks_2155_3D_bkg_irregular_energy.fits')
         assert np.all(np.isclose(background_model.data, reference.data,
@@ -108,7 +108,7 @@ class TestIntegrationClass:
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155,
                                                method='fit')
-        background_model = bkg_maker.create_acceptance_map(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_model(observations=self.obs_collection_pks_2155)
         assert type(background_model) is Background3D
         reference = Background3D.read('ressource/test_data/reference_model/pks_2155_spatial_fit_bkg_irregular_energy.fits')
         assert np.all(np.isclose(background_model.data, reference.data,
@@ -121,7 +121,7 @@ class TestIntegrationClass:
                                                offset_axis=self.offset_axis,
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155)
-        background_model = bkg_maker.create_acceptance_map(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_model(observations=self.obs_collection_pks_2155)
         assert type(background_model) is Background2D
         reference = Background2D.read('ressource/test_data/reference_model/pks_2155_2D_bkg_irregular_energy.fits')
         assert np.all(np.isclose(background_model.data, reference.data,
@@ -133,7 +133,9 @@ class TestIntegrationClass:
                                                offset_axis=self.offset_axis,
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155)
-        background_model = bkg_maker.create_acceptance_map_cos_zenith_binned(observations=self.obs_collection_pks_2155)
+        binned_background_model = bkg_maker.create_model_cos_zenith_binned(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_acceptance_map_cos_zenith_binned(observations=self.obs_collection_pks_2155,
+                                                                             model=binned_background_model)
         assert type(background_model) is dict
         for id_obs in self.id_obs_pks_2155:
             assert id_obs in background_model
@@ -148,8 +150,10 @@ class TestIntegrationClass:
                                                offset_axis=self.offset_axis,
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155)
+        binned_background_model = bkg_maker.create_model_cos_zenith_binned(observations=self.obs_collection_pks_2155)
         background_model = bkg_maker.create_acceptance_map_cos_zenith_interpolated(
-            observations=self.obs_collection_pks_2155)
+            observations=self.obs_collection_pks_2155,
+            model=binned_background_model)
         assert type(background_model) is dict
         for id_obs in self.id_obs_pks_2155:
             assert id_obs in background_model
@@ -165,8 +169,10 @@ class TestIntegrationClass:
                                                oversample_map=5,
                                                exclude_regions=self.exclude_region_PKS_2155,
                                                interpolation_zenith_type='log')
+        binned_background_model = bkg_maker.create_model_cos_zenith_binned(observations=self.obs_collection_pks_2155)
         background_model = bkg_maker.create_acceptance_map_cos_zenith_interpolated(
-            observations=self.obs_collection_pks_2155)
+            observations=self.obs_collection_pks_2155,
+            model=binned_background_model)
         assert type(background_model) is dict
         for id_obs in self.id_obs_pks_2155:
             assert id_obs in background_model
@@ -183,8 +189,10 @@ class TestIntegrationClass:
                                                exclude_regions=self.exclude_region_PKS_2155,
                                                interpolation_zenith_type='log',
                                                activate_interpolation_zenith_cleaning=True)
+        binned_background_model = bkg_maker.create_model_cos_zenith_binned(observations=self.obs_collection_pks_2155)
         background_model = bkg_maker.create_acceptance_map_cos_zenith_interpolated(
-            observations=self.obs_collection_pks_2155)
+            observations=self.obs_collection_pks_2155,
+            model=binned_background_model)
         assert type(background_model) is dict
         for id_obs in self.id_obs_pks_2155:
             assert id_obs in background_model
@@ -201,7 +209,10 @@ class TestIntegrationClass:
                                                exclude_regions=self.exclude_region_PKS_2155,
                                                use_mini_irf_computation=True,
                                                zenith_binning_run_splitting=True)
-        background_model = bkg_maker.create_acceptance_map_cos_zenith_interpolated(observations=self.obs_collection_pks_2155)
+        binned_background_model = bkg_maker.create_model_cos_zenith_binned(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_acceptance_map_cos_zenith_interpolated(
+            observations=self.obs_collection_pks_2155,
+            model=binned_background_model)
         assert type(background_model) is dict
         for id_obs in self.id_obs_pks_2155:
             assert id_obs in background_model
@@ -219,7 +230,10 @@ class TestIntegrationClass:
                                                exclude_regions=self.exclude_region_PKS_2155,
                                                use_mini_irf_computation=True,
                                                zenith_binning_run_splitting=True)
-        background_model = bkg_maker.create_acceptance_map_cos_zenith_interpolated(observations=self.obs_collection_pks_2155)
+        binned_background_model = bkg_maker.create_model_cos_zenith_binned(observations=self.obs_collection_pks_2155)
+        background_model = bkg_maker.create_acceptance_map_cos_zenith_interpolated(
+            observations=self.obs_collection_pks_2155,
+            model=binned_background_model)
         assert type(background_model) is dict
         for id_obs in self.id_obs_pks_2155:
             assert id_obs in background_model


### PR DESCRIPTION
Rework the acceptance map creator to separate the model creation and application to a set of observations. 
Also treat separated observations (e.g. fron az splitting) sequencially instead of adding the split specific method in the lower level methods.